### PR TITLE
Added delay before future request function is executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ class _CustomDropdownExampleState extends State<CustomDropdownExample> {
       futureRequest: getFakeRequestData,
       hintText: 'Search job role',
       controller: jobRoleCtrl,
+      futureRequestDelay: const Duration(seconds: 3),//it waits 3 seconds before start searching (before execute the 'futureRequest' function)
     );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -104,6 +104,7 @@ class _HomeState extends State<Home> {
             futureRequest: getFakeRequestData,
             hintText: 'Search job role',
             controller: jobRoleSearchRequestDropdownCtrl,
+            futureRequestDelay: const Duration(seconds: 3),//it waits 3 seconds before start searching (before execute the 'futureRequest' function)
           ),
           const SizedBox(height: 24),
           const Divider(height: 0),

--- a/lib/custom_dropdown.dart
+++ b/lib/custom_dropdown.dart
@@ -75,7 +75,9 @@ class CustomDropdown extends StatefulWidget {
           'Controller value must match with one of the item in items list.',
         ),
         assert(
-          (listItemBuilder == null && listItemStyle == null) || (listItemBuilder == null && listItemStyle != null) || (listItemBuilder != null && listItemStyle == null),
+          (listItemBuilder == null && listItemStyle == null) ||
+              (listItemBuilder == null && listItemStyle != null) ||
+              (listItemBuilder != null && listItemStyle == null),
           'Cannot use both listItemBuilder and listItemStyle.',
         ),
         searchType = null,
@@ -111,7 +113,9 @@ class CustomDropdown extends StatefulWidget {
           'Controller value must match with one of the item in items list.',
         ),
         assert(
-          (listItemBuilder == null && listItemStyle == null) || (listItemBuilder == null && listItemStyle != null) || (listItemBuilder != null && listItemStyle == null),
+          (listItemBuilder == null && listItemStyle == null) ||
+              (listItemBuilder == null && listItemStyle != null) ||
+              (listItemBuilder != null && listItemStyle == null),
           'Cannot use both listItemBuilder and listItemStyle.',
         ),
         searchType = _SearchType.onListData,
@@ -142,7 +146,9 @@ class CustomDropdown extends StatefulWidget {
     this.hideSelectedFieldWhenOpen = false,
     this.fillColor = Colors.white,
   })  : assert(
-          (listItemBuilder == null && listItemStyle == null) || (listItemBuilder == null && listItemStyle != null) || (listItemBuilder != null && listItemStyle == null),
+          (listItemBuilder == null && listItemStyle == null) ||
+              (listItemBuilder == null && listItemStyle != null) ||
+              (listItemBuilder != null && listItemStyle == null),
           'Cannot use both listItemBuilder and listItemStyle.',
         ),
         searchType = _SearchType.onRequestData,
@@ -182,7 +188,8 @@ class _CustomDropdownState extends State<CustomDropdown> {
           listItemBuilder: widget.listItemBuilder,
           layerLink: layerLink,
           hideOverlay: hideCallback,
-          headerStyle: widget.controller.text.isNotEmpty ? selectedStyle : hintStyle,
+          headerStyle:
+              widget.controller.text.isNotEmpty ? selectedStyle : hintStyle,
           hintText: hintText,
           listItemStyle: widget.listItemStyle,
           excludeSelected: widget.excludeSelected,

--- a/lib/custom_dropdown.dart
+++ b/lib/custom_dropdown.dart
@@ -1,14 +1,21 @@
 library animated_custom_dropdown;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 export 'custom_dropdown.dart';
 
 part 'animated_section.dart';
+
 part 'dropdown_field.dart';
+
 part 'dropdown_overlay/dropdown_overlay.dart';
-part 'dropdown_overlay/widgets/search_field.dart';
+
 part 'dropdown_overlay/widgets/items_list.dart';
+
+part 'dropdown_overlay/widgets/search_field.dart';
+
 part 'overlay_builder.dart';
 
 enum _SearchType { onListData, onRequestData }
@@ -34,8 +41,13 @@ class CustomDropdown extends StatefulWidget {
   final bool? canCloseOutsideBounds;
   final bool? hideSelectedFieldWhenOpen;
   final Future<List<String>> Function(String)? futureRequest;
+
+  //duration after which the 'futureRequest' is to be executed
+  final Duration? futureRequestDelay;
+
   // ignore: library_private_types_in_public_api
   final _SearchType? searchType;
+
   // ignore: library_private_types_in_public_api
   final _ListItemBuilder? listItemBuilder;
 
@@ -63,13 +75,12 @@ class CustomDropdown extends StatefulWidget {
           'Controller value must match with one of the item in items list.',
         ),
         assert(
-          (listItemBuilder == null && listItemStyle == null) ||
-              (listItemBuilder == null && listItemStyle != null) ||
-              (listItemBuilder != null && listItemStyle == null),
+          (listItemBuilder == null && listItemStyle == null) || (listItemBuilder == null && listItemStyle != null) || (listItemBuilder != null && listItemStyle == null),
           'Cannot use both listItemBuilder and listItemStyle.',
         ),
         searchType = null,
         futureRequest = null,
+        futureRequestDelay = null,
         canCloseOutsideBounds = true,
         hideSelectedFieldWhenOpen = false,
         super(key: key);
@@ -100,19 +111,19 @@ class CustomDropdown extends StatefulWidget {
           'Controller value must match with one of the item in items list.',
         ),
         assert(
-          (listItemBuilder == null && listItemStyle == null) ||
-              (listItemBuilder == null && listItemStyle != null) ||
-              (listItemBuilder != null && listItemStyle == null),
+          (listItemBuilder == null && listItemStyle == null) || (listItemBuilder == null && listItemStyle != null) || (listItemBuilder != null && listItemStyle == null),
           'Cannot use both listItemBuilder and listItemStyle.',
         ),
         searchType = _SearchType.onListData,
         futureRequest = null,
+        futureRequestDelay = null,
         super(key: key);
 
   const CustomDropdown.searchRequest({
     Key? key,
     required this.controller,
     required this.futureRequest,
+    this.futureRequestDelay,
     this.items,
     this.hintText,
     this.hintStyle,
@@ -131,9 +142,7 @@ class CustomDropdown extends StatefulWidget {
     this.hideSelectedFieldWhenOpen = false,
     this.fillColor = Colors.white,
   })  : assert(
-          (listItemBuilder == null && listItemStyle == null) ||
-              (listItemBuilder == null && listItemStyle != null) ||
-              (listItemBuilder != null && listItemStyle == null),
+          (listItemBuilder == null && listItemStyle == null) || (listItemBuilder == null && listItemStyle != null) || (listItemBuilder != null && listItemStyle == null),
           'Cannot use both listItemBuilder and listItemStyle.',
         ),
         searchType = _SearchType.onRequestData,
@@ -173,14 +182,14 @@ class _CustomDropdownState extends State<CustomDropdown> {
           listItemBuilder: widget.listItemBuilder,
           layerLink: layerLink,
           hideOverlay: hideCallback,
-          headerStyle:
-              widget.controller.text.isNotEmpty ? selectedStyle : hintStyle,
+          headerStyle: widget.controller.text.isNotEmpty ? selectedStyle : hintStyle,
           hintText: hintText,
           listItemStyle: widget.listItemStyle,
           excludeSelected: widget.excludeSelected,
           canCloseOutsideBounds: widget.canCloseOutsideBounds,
           searchType: widget.searchType,
           futureRequest: widget.futureRequest,
+          futureRequestDelay: widget.futureRequestDelay,
           hideSelectedFieldWhenOpen: widget.hideSelectedFieldWhenOpen,
         );
       },

--- a/lib/dropdown_overlay/dropdown_overlay.dart
+++ b/lib/dropdown_overlay/dropdown_overlay.dart
@@ -24,8 +24,10 @@ class _DropdownOverlay extends StatefulWidget {
   final bool? canCloseOutsideBounds;
   final _SearchType? searchType;
   final Future<List<String>> Function(String)? futureRequest;
+  final Duration? futureRequestDelay;
 
   final _ListItemBuilder? listItemBuilder;
+
   const _DropdownOverlay({
     Key? key,
     required this.items,
@@ -41,6 +43,7 @@ class _DropdownOverlay extends StatefulWidget {
     this.hideSelectedFieldWhenOpen = false,
     this.searchType,
     this.futureRequest,
+    this.futureRequestDelay,
     this.listItemBuilder,
   }) : super(key: key);
 
@@ -87,9 +90,7 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
     });
 
     headerText = widget.controller.text;
-    if (widget.excludeSelected! &&
-        widget.items.length > 1 &&
-        widget.controller.text.isNotEmpty) {
+    if (widget.excludeSelected! && widget.items.length > 1 && widget.controller.text.isNotEmpty) {
       items = widget.items.where((item) => item != headerText).toList();
     } else {
       items = widget.items;
@@ -113,9 +114,7 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
 
     // overlay icon
     final overlayIcon = Icon(
-      displayOverlayBottom
-          ? Icons.keyboard_arrow_up_rounded
-          : Icons.keyboard_arrow_down_rounded,
+      displayOverlayBottom ? Icons.keyboard_arrow_up_rounded : Icons.keyboard_arrow_down_rounded,
       color: Colors.black,
       size: 20,
     );
@@ -124,16 +123,14 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
     final overlayOffset = Offset(-12, displayOverlayBottom ? 0 : 60);
 
     // list padding
-    final listPadding =
-        onSearch ? const EdgeInsets.only(top: 8) : EdgeInsets.zero;
+    final listPadding = onSearch ? const EdgeInsets.only(top: 8) : EdgeInsets.zero;
 
     // items list
     final list = items.isNotEmpty
         ? _ItemsList(
             scrollController: scrollController,
             listItemBuilder: widget.listItemBuilder ?? defaultListItemBuilder,
-            excludeSelected:
-                widget.items.length > 1 ? widget.excludeSelected! : false,
+            excludeSelected: widget.items.length > 1 ? widget.excludeSelected! : false,
             items: items,
             padding: listPadding,
             headerText: headerText,
@@ -145,9 +142,7 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
               setState(() => displayOverly = false);
             },
           )
-        : (mayFoundSearchRequestResult != null &&
-                    !mayFoundSearchRequestResult!) ||
-                widget.searchType == _SearchType.onListData
+        : (mayFoundSearchRequestResult != null && !mayFoundSearchRequestResult!) || widget.searchType == _SearchType.onListData
             ? const Center(
                 child: Padding(
                   padding: EdgeInsets.symmetric(vertical: 12.0),
@@ -165,8 +160,7 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
           width: widget.size.width + 24,
           child: CompositedTransformFollower(
             link: widget.layerLink,
-            followerAnchor:
-                displayOverlayBottom ? Alignment.topLeft : Alignment.bottomLeft,
+            followerAnchor: displayOverlayBottom ? Alignment.topLeft : Alignment.bottomLeft,
             showWhenUnlinked: false,
             offset: overlayOffset,
             child: Container(
@@ -199,8 +193,7 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                           : null,
                       child: ClipRRect(
                         borderRadius: borderRadius,
-                        child: NotificationListener<
-                            OverscrollIndicatorNotification>(
+                        child: NotificationListener<OverscrollIndicatorNotification>(
                           onNotification: (notification) {
                             notification.disallowIndicator();
                             return true;
@@ -229,9 +222,7 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                       children: [
                                         Expanded(
                                           child: Text(
-                                            headerText.isNotEmpty
-                                                ? headerText
-                                                : widget.hintText,
+                                            headerText.isNotEmpty ? headerText : widget.hintText,
                                             style: widget.headerStyle,
                                             maxLines: 1,
                                             overflow: TextOverflow.ellipsis,
@@ -242,8 +233,7 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                       ],
                                     ),
                                   ),
-                                if (onSearch &&
-                                    widget.searchType == _SearchType.onListData)
+                                if (onSearch && widget.searchType == _SearchType.onListData)
                                   if (!widget.hideSelectedFieldWhenOpen!)
                                     _SearchField.forListData(
                                       items: filteredItems,
@@ -272,9 +262,7 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                         ],
                                       ),
                                     )
-                                else if (onSearch &&
-                                    widget.searchType ==
-                                        _SearchType.onRequestData)
+                                else if (onSearch && widget.searchType == _SearchType.onRequestData)
                                   if (!widget.hideSelectedFieldWhenOpen!)
                                     _SearchField.forRequestData(
                                       items: filteredItems,
@@ -284,11 +272,11 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                         });
                                       },
                                       futureRequest: widget.futureRequest,
+                                      futureRequestDelay: widget.futureRequestDelay,
                                       onSearchedItems: (val) {
                                         setState(() => items = val);
                                       },
-                                      mayFoundResult: (val) =>
-                                          mayFoundSearchRequestResult = val,
+                                      mayFoundResult: (val) => mayFoundSearchRequestResult = val,
                                     )
                                   else
                                     Padding(
@@ -306,14 +294,12 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                                   isSearchRequestLoading = val;
                                                 });
                                               },
-                                              futureRequest:
-                                                  widget.futureRequest,
+                                              futureRequest: widget.futureRequest,
+                                              futureRequestDelay: widget.futureRequestDelay,
                                               onSearchedItems: (val) {
                                                 setState(() => items = val);
                                               },
-                                              mayFoundResult: (val) =>
-                                                  mayFoundSearchRequestResult =
-                                                      val,
+                                              mayFoundResult: (val) => mayFoundSearchRequestResult = val,
                                             ),
                                           ),
                                           overlayIcon,
@@ -323,8 +309,7 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                     ),
                                 if (isSearchRequestLoading)
                                   const Padding(
-                                    padding:
-                                        EdgeInsets.symmetric(vertical: 20.0),
+                                    padding: EdgeInsets.symmetric(vertical: 20.0),
                                     child: Center(
                                         child: SizedBox(
                                       width: 25,
@@ -336,9 +321,7 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                     )),
                                   )
                                 else
-                                  items.length > 4
-                                      ? Expanded(child: list)
-                                      : list
+                                  items.length > 4 ? Expanded(child: list) : list
                               ],
                             ),
                           ),

--- a/lib/dropdown_overlay/dropdown_overlay.dart
+++ b/lib/dropdown_overlay/dropdown_overlay.dart
@@ -90,7 +90,9 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
     });
 
     headerText = widget.controller.text;
-    if (widget.excludeSelected! && widget.items.length > 1 && widget.controller.text.isNotEmpty) {
+    if (widget.excludeSelected! &&
+        widget.items.length > 1 &&
+        widget.controller.text.isNotEmpty) {
       items = widget.items.where((item) => item != headerText).toList();
     } else {
       items = widget.items;
@@ -114,7 +116,9 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
 
     // overlay icon
     final overlayIcon = Icon(
-      displayOverlayBottom ? Icons.keyboard_arrow_up_rounded : Icons.keyboard_arrow_down_rounded,
+      displayOverlayBottom
+          ? Icons.keyboard_arrow_up_rounded
+          : Icons.keyboard_arrow_down_rounded,
       color: Colors.black,
       size: 20,
     );
@@ -123,14 +127,16 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
     final overlayOffset = Offset(-12, displayOverlayBottom ? 0 : 60);
 
     // list padding
-    final listPadding = onSearch ? const EdgeInsets.only(top: 8) : EdgeInsets.zero;
+    final listPadding =
+        onSearch ? const EdgeInsets.only(top: 8) : EdgeInsets.zero;
 
     // items list
     final list = items.isNotEmpty
         ? _ItemsList(
             scrollController: scrollController,
             listItemBuilder: widget.listItemBuilder ?? defaultListItemBuilder,
-            excludeSelected: widget.items.length > 1 ? widget.excludeSelected! : false,
+            excludeSelected:
+                widget.items.length > 1 ? widget.excludeSelected! : false,
             items: items,
             padding: listPadding,
             headerText: headerText,
@@ -142,7 +148,9 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
               setState(() => displayOverly = false);
             },
           )
-        : (mayFoundSearchRequestResult != null && !mayFoundSearchRequestResult!) || widget.searchType == _SearchType.onListData
+        : (mayFoundSearchRequestResult != null &&
+                    !mayFoundSearchRequestResult!) ||
+                widget.searchType == _SearchType.onListData
             ? const Center(
                 child: Padding(
                   padding: EdgeInsets.symmetric(vertical: 12.0),
@@ -160,7 +168,8 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
           width: widget.size.width + 24,
           child: CompositedTransformFollower(
             link: widget.layerLink,
-            followerAnchor: displayOverlayBottom ? Alignment.topLeft : Alignment.bottomLeft,
+            followerAnchor:
+                displayOverlayBottom ? Alignment.topLeft : Alignment.bottomLeft,
             showWhenUnlinked: false,
             offset: overlayOffset,
             child: Container(
@@ -193,7 +202,8 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                           : null,
                       child: ClipRRect(
                         borderRadius: borderRadius,
-                        child: NotificationListener<OverscrollIndicatorNotification>(
+                        child: NotificationListener<
+                            OverscrollIndicatorNotification>(
                           onNotification: (notification) {
                             notification.disallowIndicator();
                             return true;
@@ -222,7 +232,9 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                       children: [
                                         Expanded(
                                           child: Text(
-                                            headerText.isNotEmpty ? headerText : widget.hintText,
+                                            headerText.isNotEmpty
+                                                ? headerText
+                                                : widget.hintText,
                                             style: widget.headerStyle,
                                             maxLines: 1,
                                             overflow: TextOverflow.ellipsis,
@@ -233,7 +245,8 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                       ],
                                     ),
                                   ),
-                                if (onSearch && widget.searchType == _SearchType.onListData)
+                                if (onSearch &&
+                                    widget.searchType == _SearchType.onListData)
                                   if (!widget.hideSelectedFieldWhenOpen!)
                                     _SearchField.forListData(
                                       items: filteredItems,
@@ -262,7 +275,9 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                         ],
                                       ),
                                     )
-                                else if (onSearch && widget.searchType == _SearchType.onRequestData)
+                                else if (onSearch &&
+                                    widget.searchType ==
+                                        _SearchType.onRequestData)
                                   if (!widget.hideSelectedFieldWhenOpen!)
                                     _SearchField.forRequestData(
                                       items: filteredItems,
@@ -272,11 +287,13 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                         });
                                       },
                                       futureRequest: widget.futureRequest,
-                                      futureRequestDelay: widget.futureRequestDelay,
+                                      futureRequestDelay:
+                                          widget.futureRequestDelay,
                                       onSearchedItems: (val) {
                                         setState(() => items = val);
                                       },
-                                      mayFoundResult: (val) => mayFoundSearchRequestResult = val,
+                                      mayFoundResult: (val) =>
+                                          mayFoundSearchRequestResult = val,
                                     )
                                   else
                                     Padding(
@@ -294,12 +311,16 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                                   isSearchRequestLoading = val;
                                                 });
                                               },
-                                              futureRequest: widget.futureRequest,
-                                              futureRequestDelay: widget.futureRequestDelay,
+                                              futureRequest:
+                                                  widget.futureRequest,
+                                              futureRequestDelay:
+                                                  widget.futureRequestDelay,
                                               onSearchedItems: (val) {
                                                 setState(() => items = val);
                                               },
-                                              mayFoundResult: (val) => mayFoundSearchRequestResult = val,
+                                              mayFoundResult: (val) =>
+                                                  mayFoundSearchRequestResult =
+                                                      val,
                                             ),
                                           ),
                                           overlayIcon,
@@ -309,7 +330,8 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                     ),
                                 if (isSearchRequestLoading)
                                   const Padding(
-                                    padding: EdgeInsets.symmetric(vertical: 20.0),
+                                    padding:
+                                        EdgeInsets.symmetric(vertical: 20.0),
                                     child: Center(
                                         child: SizedBox(
                                       width: 25,
@@ -321,7 +343,9 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                     )),
                                   )
                                 else
-                                  items.length > 4 ? Expanded(child: list) : list
+                                  items.length > 4
+                                      ? Expanded(child: list)
+                                      : list
                               ],
                             ),
                           ),

--- a/lib/dropdown_overlay/widgets/search_field.dart
+++ b/lib/dropdown_overlay/widgets/search_field.dart
@@ -44,7 +44,8 @@ class _SearchFieldState extends State<_SearchField> {
   @override
   void initState() {
     super.initState();
-    if (widget.searchType == _SearchType.onRequestData && widget.items.isEmpty) {
+    if (widget.searchType == _SearchType.onRequestData &&
+        widget.items.isEmpty) {
       focusNode.requestFocus();
     }
   }
@@ -57,7 +58,9 @@ class _SearchFieldState extends State<_SearchField> {
   }
 
   void onSearch(String str) {
-    final result = widget.items.where((item) => item.toLowerCase().contains(str.toLowerCase())).toList();
+    final result = widget.items
+        .where((item) => item.toLowerCase().contains(str.toLowerCase()))
+        .toList();
     widget.onSearchedItems(result);
   }
 
@@ -97,12 +100,15 @@ class _SearchFieldState extends State<_SearchField> {
             isFieldEmpty = false;
           }
 
-          if (widget.searchType != null && widget.searchType == _SearchType.onRequestData && val.isNotEmpty) {
+          if (widget.searchType != null &&
+              widget.searchType == _SearchType.onRequestData &&
+              val.isNotEmpty) {
             widget.onFutureRequestLoading!(true);
 
             if (widget.futureRequestDelay != null) {
               _delayTimer?.cancel();
-              _delayTimer = Timer(widget.futureRequestDelay ?? Duration.zero, () {
+              _delayTimer =
+                  Timer(widget.futureRequestDelay ?? Duration.zero, () {
                 searchRequest(val);
               });
             } else {

--- a/lib/dropdown_overlay/widgets/search_field.dart
+++ b/lib/dropdown_overlay/widgets/search_field.dart
@@ -68,6 +68,22 @@ class _SearchFieldState extends State<_SearchField> {
     }
   }
 
+  void searchRequest(String val) async {
+    List<String> result = [];
+    try {
+      result = await widget.futureRequest!(val);
+      widget.onFutureRequestLoading!(false);
+    } catch (_) {
+      widget.onFutureRequestLoading!(false);
+    }
+    widget.onSearchedItems(isFieldEmpty ? widget.items : result);
+    widget.mayFoundResult!(result.isNotEmpty);
+
+    if (isFieldEmpty) {
+      isFieldEmpty = false;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -82,25 +98,16 @@ class _SearchFieldState extends State<_SearchField> {
           }
 
           if (widget.searchType != null && widget.searchType == _SearchType.onRequestData && val.isNotEmpty) {
-            _delayTimer?.cancel();
-
-            List<String>? result;
             widget.onFutureRequestLoading!(true);
 
-            _delayTimer = Timer(widget.futureRequestDelay ?? const Duration(), () async {
-              try {
-                result = await widget.futureRequest!(val);
-                widget.onFutureRequestLoading!(false);
-              } catch (_) {
-                widget.onFutureRequestLoading!(false);
-              }
-              widget.onSearchedItems(isFieldEmpty ? widget.items : result ?? []);
-              widget.mayFoundResult!(result?.isNotEmpty ?? false);
-
-              if (isFieldEmpty) {
-                isFieldEmpty = false;
-              }
-            });
+            if (widget.futureRequestDelay != null) {
+              _delayTimer?.cancel();
+              _delayTimer = Timer(widget.futureRequestDelay ?? Duration.zero, () {
+                searchRequest(val);
+              });
+            } else {
+              searchRequest(val);
+            }
           } else if (widget.searchType == _SearchType.onListData) {
             onSearch(val);
           } else {

--- a/lib/dropdown_overlay/widgets/search_field.dart
+++ b/lib/dropdown_overlay/widgets/search_field.dart
@@ -84,10 +84,10 @@ class _SearchFieldState extends State<_SearchField> {
           if (widget.searchType != null && widget.searchType == _SearchType.onRequestData && val.isNotEmpty) {
             _delayTimer?.cancel();
 
-            _delayTimer = Timer(widget.futureRequestDelay ?? const Duration(), () async {
-              List<String>? result;
-              widget.onFutureRequestLoading!(true);
+            List<String>? result;
+            widget.onFutureRequestLoading!(true);
 
+            _delayTimer = Timer(widget.futureRequestDelay ?? const Duration(), () async {
               try {
                 result = await widget.futureRequest!(val);
                 widget.onFutureRequestLoading!(false);


### PR DESCRIPTION
In the `futureRequest` of the `CustomDropdown.searchRequest`, I get data from an API (google places with [places_service](https://pub.dev/packages/places_service)), but every time the user types a letter, the function is executed and an api call is made, causing an overfetching of the service.
The simplest solution (in my opinion) would be to execute the `futureRequest` after a certain period of time, period of time that restarts if you type another letter.

The implementation is basically adding the `Duration: futureRequestDelay` property as part of the `CustomDropdown.searchRequest` constructor, this property is not required and defaults to no delay. Finally, before executing the search function, the time designated in this variable is waited. If another letter is typed during the waiting period, the waiting time is restarted.