### PR TITLE
Simple Theme Integration

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
+// This new app avoids using constant color values.
+
 import 'package:animated_custom_dropdown/custom_dropdown.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 void main() {
   runApp(const App());
@@ -11,10 +12,20 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    const themeSeedColor = Colors.blue;
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Custom Dropdown App',
-      home: Home(),
+      home: const Home(),
+      theme: ThemeData(
+        brightness: Brightness.light,
+        colorScheme: ColorScheme.fromSeed(brightness: Brightness.light, seedColor: themeSeedColor),
+      ),
+      darkTheme: ThemeData(
+        brightness: Brightness.dark,
+        colorScheme: ColorScheme.fromSeed(brightness: Brightness.dark, seedColor: themeSeedColor),
+      ),
+      themeMode: ThemeMode.dark,
     );
   }
 }
@@ -58,16 +69,10 @@ class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.grey[200],
       appBar: AppBar(
-        systemOverlayStyle: SystemUiOverlayStyle.dark.copyWith(
-          statusBarColor: Colors.white,
-        ),
-        backgroundColor: Colors.white,
         elevation: .25,
         title: const Text(
-          'Custom Dropdown Example',
-          style: TextStyle(color: Colors.black, fontSize: 18),
+          'Custom Dropdown Example'
         ),
       ),
       body: ListView(

--- a/lib/custom_dropdown.dart
+++ b/lib/custom_dropdown.dart
@@ -68,7 +68,7 @@ class CustomDropdown extends StatefulWidget {
     this.fieldSuffixIcon,
     this.onChanged,
     this.excludeSelected = true,
-    this.fillColor = Colors.white,
+    this.fillColor,
   })  : assert(items!.isNotEmpty, 'Items list must contain at least one item.'),
         assert(
           controller.text.isEmpty || items!.contains(controller.text),
@@ -106,7 +106,7 @@ class CustomDropdown extends StatefulWidget {
     this.excludeSelected = true,
     this.canCloseOutsideBounds = true,
     this.hideSelectedFieldWhenOpen = false,
-    this.fillColor = Colors.white,
+    this.fillColor,
   })  : assert(items!.isNotEmpty, 'Items list must contain at least one item.'),
         assert(
           controller.text.isEmpty || items!.contains(controller.text),
@@ -144,7 +144,8 @@ class CustomDropdown extends StatefulWidget {
     this.excludeSelected = true,
     this.canCloseOutsideBounds = true,
     this.hideSelectedFieldWhenOpen = false,
-    this.fillColor = Colors.white,
+    // removed default white color.
+    this.fillColor,
   })  : assert(
           (listItemBuilder == null && listItemStyle == null) ||
               (listItemBuilder == null && listItemStyle != null) ||

--- a/lib/dropdown_field.dart
+++ b/lib/dropdown_field.dart
@@ -2,7 +2,6 @@ part of 'custom_dropdown.dart';
 
 const _textFieldIcon = Icon(
   Icons.keyboard_arrow_down_rounded,
-  color: Colors.black,
   size: 20,
 );
 const _contentPadding = EdgeInsets.only(left: 16);

--- a/lib/dropdown_overlay/dropdown_overlay.dart
+++ b/lib/dropdown_overlay/dropdown_overlay.dart
@@ -119,7 +119,6 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
       displayOverlayBottom
           ? Icons.keyboard_arrow_up_rounded
           : Icons.keyboard_arrow_down_rounded,
-      color: Colors.black,
       size: 20,
     );
 
@@ -177,12 +176,12 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
               padding: _overlayOuterPadding,
               child: DecoratedBox(
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: Theme.of(context).dialogBackgroundColor,
                   borderRadius: borderRadius,
                   boxShadow: [
                     BoxShadow(
                       blurRadius: 24.0,
-                      color: Colors.black.withOpacity(.08),
+                      color: Theme.of(context).shadowColor.withOpacity(.08),
                       offset: _overlayShadowOffset,
                     ),
                   ],
@@ -216,9 +215,6 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                 ),
                                 thickness: MaterialStateProperty.all(5),
                                 radius: const Radius.circular(4),
-                                thumbColor: MaterialStateProperty.all(
-                                  Colors.grey[300],
-                                ),
                               ),
                             ),
                             child: Column(
@@ -337,7 +333,6 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
                                       width: 25,
                                       height: 25,
                                       child: CircularProgressIndicator(
-                                        color: Colors.black,
                                         strokeWidth: 3,
                                       ),
                                     )),

--- a/lib/dropdown_overlay/widgets/items_list.dart
+++ b/lib/dropdown_overlay/widgets/items_list.dart
@@ -37,10 +37,9 @@ class _ItemsList extends StatelessWidget {
             color: Colors.transparent,
             child: InkWell(
               splashColor: Colors.transparent,
-              highlightColor: Colors.grey[200],
               onTap: () => onItemSelect(items[index]),
               child: Container(
-                color: selected ? Colors.grey[100] : Colors.transparent,
+                color: selected ? Theme.of(context).highlightColor : Colors.transparent,
                 padding: _listItemPadding,
                 child: listItemBuilder(context, items[index]),
               ),

--- a/lib/dropdown_overlay/widgets/search_field.dart
+++ b/lib/dropdown_overlay/widgets/search_field.dart
@@ -44,8 +44,7 @@ class _SearchFieldState extends State<_SearchField> {
   @override
   void initState() {
     super.initState();
-    if (widget.searchType == _SearchType.onRequestData &&
-        widget.items.isEmpty) {
+    if (widget.searchType == _SearchType.onRequestData && widget.items.isEmpty) {
       focusNode.requestFocus();
     }
   }
@@ -58,9 +57,7 @@ class _SearchFieldState extends State<_SearchField> {
   }
 
   void onSearch(String str) {
-    final result = widget.items
-        .where((item) => item.toLowerCase().contains(str.toLowerCase()))
-        .toList();
+    final result = widget.items.where((item) => item.toLowerCase().contains(str.toLowerCase())).toList();
     widget.onSearchedItems(result);
   }
 
@@ -89,6 +86,7 @@ class _SearchFieldState extends State<_SearchField> {
 
   @override
   Widget build(BuildContext context) {
+    final hintColor = Theme.of(context).hintColor;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8),
       child: TextField(
@@ -100,15 +98,12 @@ class _SearchFieldState extends State<_SearchField> {
             isFieldEmpty = false;
           }
 
-          if (widget.searchType != null &&
-              widget.searchType == _SearchType.onRequestData &&
-              val.isNotEmpty) {
+          if (widget.searchType != null && widget.searchType == _SearchType.onRequestData && val.isNotEmpty) {
             widget.onFutureRequestLoading!(true);
 
             if (widget.futureRequestDelay != null) {
               _delayTimer?.cancel();
-              _delayTimer =
-                  Timer(widget.futureRequestDelay ?? Duration.zero, () {
+              _delayTimer = Timer(widget.futureRequestDelay ?? Duration.zero, () {
                 searchRequest(val);
               });
             } else {
@@ -123,34 +118,32 @@ class _SearchFieldState extends State<_SearchField> {
         controller: searchCtrl,
         decoration: InputDecoration(
           filled: true,
-          fillColor: Colors.grey[50],
           constraints: const BoxConstraints.tightFor(height: 40),
           contentPadding: const EdgeInsets.all(8),
           hintText: 'Search',
-          hintStyle: const TextStyle(color: Colors.grey),
-          prefixIcon: const Icon(Icons.search, color: Colors.grey, size: 22),
+          prefixIcon: Icon(Icons.search, color: hintColor, size: 22),
           suffixIcon: GestureDetector(
             onTap: onClear,
-            child: const Icon(Icons.close, color: Colors.grey, size: 20),
+            child: Icon(Icons.close, color: hintColor, size: 20),
           ),
           border: OutlineInputBorder(
             borderRadius: BorderRadius.circular(8),
             borderSide: BorderSide(
-              color: Colors.grey.withOpacity(.25),
+              color: hintColor.withOpacity(.25),
               width: 1,
             ),
           ),
           enabledBorder: OutlineInputBorder(
             borderRadius: BorderRadius.circular(8),
             borderSide: BorderSide(
-              color: Colors.grey.withOpacity(.25),
+              color: hintColor.withOpacity(.25),
               width: 1,
             ),
           ),
           focusedBorder: OutlineInputBorder(
             borderRadius: BorderRadius.circular(8),
             borderSide: BorderSide(
-              color: Colors.grey.withOpacity(.25),
+              color: hintColor.withOpacity(.25),
               width: 1,
             ),
           ),


### PR DESCRIPTION
# Theme Integration

I love this package and its nice looking, but I felt a bit uncomfortable as I use dark mode while this package uses only constant light colors. Moreover, I cannot set a builder parameter for the dropdown field. So I simply applied theme color values.

I think many user would use theme system so if this pull request is published, many of them may not need some complicated builders to customize it.

I've committed a modification of `main.dart` file too, and it is unnecessary for the production but I recommend you to merge it too.

_**Ready for production**_

---
![Light Mode](https://github.com/AbdullahChauhan/custom-dropdown/assets/50483226/ddd28d5b-9147-46f7-85d9-289aadf9b1d9)
![Dark Mode](https://github.com/AbdullahChauhan/custom-dropdown/assets/50483226/50ce7791-0a8b-4919-976d-ca79c3957d1c)