### PR TITLE
Fixed issue: dropdown being closed on click scroll view when it is being scrolled.

### DIFF
--- a/lib/dropdown_overlay/dropdown_overlay.dart
+++ b/lib/dropdown_overlay/dropdown_overlay.dart
@@ -361,16 +361,19 @@ class _DropdownOverlayState extends State<_DropdownOverlay> {
       ],
     );
 
-    return GestureDetector(
-      onTap: () => setState(() => displayOverly = false),
-      child: widget.canCloseOutsideBounds!
-          ? Container(
+    return Stack(
+      children: [
+        if (widget.canCloseOutsideBounds!)
+          GestureDetector(
+            onTap: () => setState(() => displayOverly = false),
+            child: Container(
               width: MediaQuery.of(context).size.width,
               height: MediaQuery.of(context).size.height,
               color: Colors.transparent,
-              child: child,
-            )
-          : child,
+            ),
+          ),
+        child,
+      ],
     );
   }
 }


### PR DESCRIPTION
_I tested this in IOS_

I clicked the dropdown's scroll view to stop scrolling, and I expected that it would stop scrolling, the field was closed.

originally, because the dropdown field had been wrapped with a GestureDetector as a child, the gesture action had been applied to that child too, where it shouldn't happen.

Instead, I separated and placed them in a Stack, so this issue was fixed.