### PR TITLE
Fix: onChanged not invoked after first invocation

### DIFF
--- a/example/lib/widgets/search_dropdown.dart
+++ b/example/lib/widgets/search_dropdown.dart
@@ -12,16 +12,26 @@ const _list = [
   'Italian',
 ];
 
-class SearchDropdown extends StatelessWidget {
+class SearchDropdown extends StatefulWidget {
   const SearchDropdown({Key? key}) : super(key: key);
 
+  @override
+  State<SearchDropdown> createState() => _SearchDropdownState();
+}
+
+class _SearchDropdownState extends State<SearchDropdown> {
+  String? _selectedItem = _list[2];
   @override
   Widget build(BuildContext context) {
     return CustomDropdown<String>.search(
       hintText: 'Select cuisines',
       items: _list,
+      initialItem: _selectedItem,
       overlayHeight: 342,
       onChanged: (value) {
+        setState(() {
+          _selectedItem = value;
+        });
         log('SearchDropdown onChanged value: $value');
       },
     );

--- a/example/lib/widgets/simple_dropdown.dart
+++ b/example/lib/widgets/simple_dropdown.dart
@@ -10,18 +10,27 @@ const List<String> _list = [
   'Student',
 ];
 
-class SimpleDropdown extends StatelessWidget {
+class SimpleDropdown extends StatefulWidget {
   const SimpleDropdown({Key? key}) : super(key: key);
 
+  @override
+  State<SimpleDropdown> createState() => _SimpleDropdownState();
+}
+
+class _SimpleDropdownState extends State<SimpleDropdown> {
+  String? _selectedItem;
   @override
   Widget build(BuildContext context) {
     return CustomDropdown<String>(
       hintText: 'Select job role',
       items: _list,
-      initialItem: _list[0],
+      initialItem: _selectedItem,
       excludeSelected: false,
       onChanged: (value) {
         log('SimpleDropdown onChanged value: $value');
+        setState(() {
+          _selectedItem = value;
+        });
       },
     );
   }

--- a/lib/custom_dropdown.dart
+++ b/lib/custom_dropdown.dart
@@ -3,6 +3,7 @@ library animated_custom_dropdown;
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 export 'custom_dropdown.dart';
 
@@ -540,12 +541,18 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
   void didUpdateWidget(covariant CustomDropdown<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (widget.initialItem != oldWidget.initialItem) {
-      selectedItemNotifier = SingleSelectController(widget.initialItem);
+    if (widget.initialItem != oldWidget.initialItem &&
+        selectedItemNotifier.value != widget.initialItem) {
+      SchedulerBinding.instance.addPostFrameCallback((timeStamp) {
+        selectedItemNotifier.value = widget.initialItem;
+      });
     }
 
-    if (widget.initialItems != oldWidget.initialItems) {
-      selectedItemsNotifier = MultiSelectController(widget.initialItems ?? []);
+    if (widget.initialItems != oldWidget.initialItems &&
+        selectedItemsNotifier.value != widget.initialItems) {
+      SchedulerBinding.instance.addPostFrameCallback((timeStamp) {
+        selectedItemsNotifier.value = widget.initialItems ?? [];
+      });
     }
 
     if (widget.controller != oldWidget.controller &&


### PR DESCRIPTION
In the custom_dropdown.dart, the didUpdateWidget method changes the selectedItemNotifier and selectedItemsNotifier to a new instance when the widget configuration is inconsistent.

This causes two problems, first if the end user supplied the controller then it will be overriden. Secondly, new instance is not required, and even if created should have attached the listeners to the the new instance.

This commit solves the problem by updating the earlier instance of the notifier to the new value via SchedulerBinding. Also, the two examples have been changed to use the stateful widget, which solves the current problem.