### PR TITLE
[Enhancement] Added align text issue: Align Header text and dropdown item text #71

### DIFF
--- a/lib/custom_dropdown.dart
+++ b/lib/custom_dropdown.dart
@@ -110,6 +110,10 @@ class CustomDropdown<T> extends StatefulWidget {
   /// Text maxlines for header and list item text.
   final int maxlines;
 
+  /// Text align for head, hint and list item and so on.
+  /// Default [TextAlign.start]
+  final TextAlign textAlign;
+
   /// Padding for [CustomDropdown] header (closed state).
   final EdgeInsets? closedHeaderPadding;
 
@@ -197,6 +201,7 @@ class CustomDropdown<T> extends StatefulWidget {
     this.headerBuilder,
     this.hintBuilder,
     this.maxlines = 1,
+    this.textAlign = TextAlign.start,
     this.overlayHeight,
     this.closedHeaderPadding,
     this.expandedHeaderPadding,
@@ -256,6 +261,7 @@ class CustomDropdown<T> extends StatefulWidget {
     this.validator,
     this.validateOnChange = true,
     this.maxlines = 1,
+    this.textAlign = TextAlign.start,
     this.overlayHeight,
     this.closedHeaderPadding,
     this.expandedHeaderPadding,
@@ -314,6 +320,7 @@ class CustomDropdown<T> extends StatefulWidget {
     this.validator,
     this.validateOnChange = true,
     this.maxlines = 1,
+    this.textAlign = TextAlign.start,
     this.overlayHeight,
     this.closedHeaderPadding,
     this.expandedHeaderPadding,
@@ -358,6 +365,7 @@ class CustomDropdown<T> extends StatefulWidget {
     this.canCloseOutsideBounds = true,
     this.hideSelectedFieldWhenExpanded = false,
     this.maxlines = 1,
+    this.textAlign = TextAlign.start,
     this.overlayHeight,
     this.closedHeaderPadding,
     this.expandedHeaderPadding,
@@ -419,6 +427,7 @@ class CustomDropdown<T> extends StatefulWidget {
     this.canCloseOutsideBounds = true,
     this.hideSelectedFieldWhenExpanded = false,
     this.maxlines = 1,
+    this.textAlign = TextAlign.start,
     this.overlayHeight,
     this.closedHeaderPadding,
     this.expandedHeaderPadding,
@@ -477,6 +486,7 @@ class CustomDropdown<T> extends StatefulWidget {
     this.listValidator,
     this.validateOnChange = true,
     this.maxlines = 1,
+    this.textAlign = TextAlign.start,
     this.overlayHeight,
     this.searchRequestLoadingIndicator,
     this.closedHeaderPadding,
@@ -639,6 +649,7 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
                   listItemBuilder: widget.listItemBuilder,
                   layerLink: layerLink,
                   hideOverlay: hideCallback,
+                  textAlign: widget.textAlign,
                   hintStyle: decoration?.hintStyle,
                   headerStyle: decoration?.headerStyle,
                   noResultFoundStyle: decoration?.noResultFoundStyle,
@@ -682,6 +693,7 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
                         : enabled
                             ? decoration?.closedBorderRadius
                             : disabledDecoration?.borderRadius,
+                    textAlign: widget.textAlign,
                     shadow: enabled
                         ? decoration?.closedShadow
                         : disabledDecoration?.shadow,

--- a/lib/widgets/dropdown_field.dart
+++ b/lib/widgets/dropdown_field.dart
@@ -13,6 +13,7 @@ class _DropDownField<T> extends StatefulWidget {
   final Color? fillColor;
   final BoxBorder? border;
   final BorderRadius? borderRadius;
+  final TextAlign? textAlign;
   final TextStyle? headerStyle, hintStyle;
   final Widget? prefixIcon, suffixIcon;
   final List<BoxShadow>? shadow;
@@ -36,6 +37,7 @@ class _DropDownField<T> extends StatefulWidget {
     this.fillColor,
     this.border,
     this.borderRadius,
+    this.textAlign,
     this.hintStyle,
     this.headerStyle,
     this.headerBuilder,
@@ -85,6 +87,7 @@ class _DropDownFieldState<T> extends State<_DropDownField<T>> {
     return Text(
       itemList != null ? itemList.join(', ') : oneItem.toString(),
       maxLines: widget.maxLines,
+      textAlign: widget.textAlign,
       overflow: TextOverflow.ellipsis,
       style: widget.headerStyle ??
           TextStyle(
@@ -100,6 +103,7 @@ class _DropDownFieldState<T> extends State<_DropDownField<T>> {
       hint,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
+      textAlign: widget.textAlign,
       style: widget.hintStyle ??
           const TextStyle(
             fontSize: 16,

--- a/lib/widgets/dropdown_overlay/dropdown_overlay.dart
+++ b/lib/widgets/dropdown_overlay/dropdown_overlay.dart
@@ -28,6 +28,7 @@ class _DropdownOverlay<T> extends StatefulWidget {
   final Duration? futureRequestDelay;
   final int maxLines;
   final double? overlayHeight;
+  final TextAlign? textAlign;
   final TextStyle? hintStyle, headerStyle, noResultFoundStyle, listItemStyle;
   final EdgeInsets? headerPadding, listItemPadding, itemsListPadding;
   final Widget? searchRequestLoadingIndicator;
@@ -56,6 +57,7 @@ class _DropdownOverlay<T> extends StatefulWidget {
     required this.canCloseOutsideBounds,
     required this.maxLines,
     required this.overlayHeight,
+    required this.textAlign,
     required this.dropdownType,
     required this.decoration,
     required this.hintStyle,
@@ -127,6 +129,7 @@ class _DropdownOverlayState<T> extends State<_DropdownOverlay<T>> {
           child: Text(
             result.toString(),
             maxLines: widget.maxLines,
+            textAlign: widget.textAlign,
             overflow: TextOverflow.ellipsis,
             style: widget.listItemStyle ?? const TextStyle(fontSize: 16),
           ),
@@ -156,6 +159,7 @@ class _DropdownOverlayState<T> extends State<_DropdownOverlay<T>> {
     return Text(
       items != null ? items.join(', ') : item.toString(),
       maxLines: widget.maxLines,
+      textAlign: widget.textAlign,
       overflow: TextOverflow.ellipsis,
       style: widget.headerStyle ??
           const TextStyle(
@@ -169,6 +173,7 @@ class _DropdownOverlayState<T> extends State<_DropdownOverlay<T>> {
     return Text(
       hint,
       maxLines: 1,
+      textAlign: widget.textAlign,
       overflow: TextOverflow.ellipsis,
       style: widget.hintStyle ??
           const TextStyle(


### PR DESCRIPTION
Hi, @AbdullahChauhan .
I modified your animated_custom_dropdown library because I need to feature align to text.
It's default value is `TextAlign.start`.


Usage
```dart
  @override
  Widget build(BuildContext context) {
    return CustomDropdown<String>(
      hintText: 'Select job role',
      items: _list,
      initialItem: _list[0],
      excludeSelected: false,
      onChanged: (value) {
        log('SimpleDropdown onChanged value: $value');
      },
      textAlign: TextAlign.center,    // Here ! -- 
    );
  }
```

![20240527_173740](https://github.com/user-attachments/assets/d06cd246-0f44-4a42-badf-e2b16f661b08)


Your library is very nice!
We will be good friend :)

Have a nice day!