### PR TITLE
Fix Gray Background Issue on Error in CustomDropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Miscellaneous
 *.class
+*.lock
 *.log
 *.pyc
 *.swp
@@ -15,29 +16,59 @@
 *.iws
 .idea/
 
-# The .vscode folder contains launch configuration and tasks you configure in
-# VS Code which you may wish to be included in version control, so this line
-# is commented out by default.
-#.vscode/
+# Visual Studio Code related
+.classpath
+.project
+.settings/
+.vscode/
+
+# Flutter repo-specific
+/bin/cache/
+/bin/internal/bootstrap.bat
+/bin/internal/bootstrap.sh
+/bin/mingit/
+/dev/benchmarks/mega_gallery/
+/dev/bots/.recipe_deps
+/dev/bots/android_tools/
+/dev/devicelab/ABresults*.json
+/dev/docs/doc/
+/dev/docs/flutter.docs.zip
+/dev/docs/lib/
+/dev/docs/pubspec.yaml
+/dev/integration_tests/**/xcuserdata
+/dev/integration_tests/**/Pods
+/packages/flutter/coverage/
+version
+analysis_benchmark.json
+
+# packages file containing multi-root paths
+.packages.generated
 
 # Flutter/Dart/Pub related
 **/doc/api/
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies
+**/generated_plugin_registrant.dart
 .packages
 .pub-cache/
 .pub/
 build/
+flutter_*.png
+linked_*.ds
+unlinked.ds
+unlinked_spec.ds
 
 # Android related
 **/android/**/gradle-wrapper.jar
-**/android/.gradle
+.gradle/
 **/android/captures/
 **/android/gradlew
 **/android/gradlew.bat
 **/android/local.properties
 **/android/**/GeneratedPluginRegistrant.java
+**/android/key.properties
+*.jks
 
 # iOS/XCode related
 **/ios/**/*.mode1v3
@@ -56,6 +87,7 @@ build/
 **/ios/**/profile
 **/ios/**/xcuserdata
 **/ios/.generated/
+**/ios/Flutter/.last_build_id
 **/ios/Flutter/App.framework
 **/ios/Flutter/Flutter.framework
 **/ios/Flutter/Flutter.podspec
@@ -68,8 +100,42 @@ build/
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 
+# macOS
+**/Flutter/ephemeral/
+**/Pods/
+**/macos/Flutter/GeneratedPluginRegistrant.swift
+**/macos/Flutter/ephemeral
+**/xcuserdata/
+
+# Windows
+**/windows/flutter/generated_plugin_registrant.cc
+**/windows/flutter/generated_plugin_registrant.h
+**/windows/flutter/generated_plugins.cmake
+
+# Linux
+**/linux/flutter/generated_plugin_registrant.cc
+**/linux/flutter/generated_plugin_registrant.h
+**/linux/flutter/generated_plugins.cmake
+
+# Coverage
+coverage/
+
+# Symbols
+app.*.symbols
+
 # Exceptions to above rules.
 !**/ios/**/default.mode1v3
 !**/ios/**/default.mode2v3
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+!/dev/ci/**/Gemfile.lock
+
+Icon*
+pushes/
+*.env
+.env.*
+*.fvm
+.fvm/*
+.fvm
+.fvmrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 3.1.2
+
+Fixed
+- Error Background Color**: Resolved an issue where a gray background would appear when an error message was displayed in the `CustomDropdown` widget. The `InputDecorator` within the `_CustomDropdownState` class now sets the `fillColor` to `Colors.transparent` when an error occurs, ensuring a consistent appearance without an unwanted background color.
+
+Changed
+- CustomDropdown**: Updated the `InputDecorator` in the `_CustomDropdownState` class to handle error states more effectively. The `fillColor` is now conditionally set based on the presence of an error, and the `filled` property is enabled to apply the `fillColor`.
+
+Notes
+- Ensure that any custom decorations applied to the `CustomDropdown` widget are compatible with these changes to maintain the desired appearance and functionality.
+  
 # 3.1.1
 
 - Fix: onChanged not invoked after first invocation (Thanks [@ravindrabarthwal for PR](https://github.com/AbdullahChauhan/custom-dropdown/pull/76))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # 3.1.2
 
-Fixed
-- Error Background Color**: Resolved an issue where a gray background would appear when an error message was displayed in the `CustomDropdown` widget. The `InputDecorator` within the `_CustomDropdownState` class now sets the `fillColor` to `Colors.transparent` when an error occurs, ensuring a consistent appearance without an unwanted background color.
+### Fixed
+- **Error Background Color**: Resolved an issue where a gray background would appear when an error message was displayed in the `CustomDropdown` widget. The `InputDecorator` within the `_CustomDropdownState` class now sets the `fillColor` to `Colors.transparent` when an error occurs, ensuring a consistent appearance without an unwanted background color.
 
-Changed
-- CustomDropdown**: Updated the `InputDecorator` in the `_CustomDropdownState` class to handle error states more effectively. The `fillColor` is now conditionally set based on the presence of an error, and the `filled` property is enabled to apply the `fillColor`.
+### Changed
+- **CustomDropdown**: Updated the `InputDecorator` in the `_CustomDropdownState` class to handle error states more effectively. The `fillColor` is now conditionally set based on the presence of an error, and the `filled` property is enabled to apply the `fillColor`.
 
-Notes
+### Notes
 - Ensure that any custom decorations applied to the `CustomDropdown` widget are compatible with these changes to maintain the desired appearance and functionality.
-  
+
 # 3.1.1
 
 - Fix: onChanged not invoked after first invocation (Thanks [@ravindrabarthwal for PR](https://github.com/AbdullahChauhan/custom-dropdown/pull/76))
@@ -42,28 +42,6 @@ Notes
     - `SearchFieldDecoration`
     - `ListItemDecoration`
     - `ScrollbarThemeData`
-- Add: Dropdown overlay height support (Thanks [@aguilastorm for PR](https://github.com/AbdullahChauhan/custom-dropdown/pull/38))
-  - `overlayHeight`
-- Add: Custom loading widget for search request
-  - `searchRequestLoadingIndicator`
-- Add: Padding properties:
-  - `closedHeaderPadding`
-  - `expandedHeaderPadding`
-  - `itemsListPadding`
-  - `listItemPadding`
-- Fix: Stop the scrolling and dropdown should remains in expanded state (Thanks [@s-saens for PR](https://github.com/AbdullahChauhan/custom-dropdown/pull/34))
-- Breaking: Properties move inside decoration:
-  - `closedFillColor`
-  - `expandedFillColor`
-  - `errorStyle`
-  - `closedBorder`
-  - `closedBorderRadius`
-  - `expandedBorder`
-  - `expandedBorderRadius`
-  - `closedErrorBorder`
-  - `closedErrorBorderRadius`
-  - `closedSuffixIcon`
-  - `expandedSuffixIcon`
 
 # 2.0.0
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -86,18 +86,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -126,18 +126,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -195,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -211,10 +211,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
 sdks:
   dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/custom_dropdown.dart
+++ b/lib/custom_dropdown.dart
@@ -7,12 +7,12 @@ import 'package:flutter/scheduler.dart';
 
 export 'custom_dropdown.dart';
 
+part 'models/controllers.dart';
 // models
 part 'models/custom_dropdown_decoration.dart';
 part 'models/custom_dropdown_list_filter.dart';
 part 'models/disabled_decoration.dart';
 part 'models/list_item_decoration.dart';
-part 'models/controllers.dart';
 part 'models/search_field_decoration.dart';
 // utils
 part 'utils/signatures.dart';
@@ -216,9 +216,7 @@ class CustomDropdown<T> extends StatefulWidget {
           'Initial item must match with one of the item in items list.',
         ),
         assert(
-          controller == null ||
-              controller.value == null ||
-              items!.contains(controller.value),
+          controller == null || controller.value == null || items!.contains(controller.value),
           'Controller value must match with one of the item in items list.',
         ),
         _searchType = null,
@@ -276,9 +274,7 @@ class CustomDropdown<T> extends StatefulWidget {
           'Initial item must match with one of the item in items list.',
         ),
         assert(
-          controller == null ||
-              controller.value == null ||
-              items!.contains(controller.value),
+          controller == null || controller.value == null || items!.contains(controller.value),
           'Controller value must match with one of the item in items list.',
         ),
         _searchType = _SearchType.onListData,
@@ -510,35 +506,30 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
   late MultiSelectController<T> selectedItemsNotifier;
   FormFieldState<(T?, List<T>)>? _formFieldState;
 
-  void _selectedItemListener() {
-    widget.onChanged?.call(selectedItemNotifier.value);
-    _formFieldState?.didChange((selectedItemNotifier.value, []));
-    if (widget.validateOnChange) {
-      _formFieldState?.validate();
-    }
-  }
-
-  void _selectedItemsListener() {
-    widget.onListChanged?.call(selectedItemsNotifier.value);
-    _formFieldState?.didChange((null, selectedItemsNotifier.value));
-    if (widget.validateOnChange) {
-      _formFieldState?.validate();
-    }
-  }
-
   @override
   void initState() {
     super.initState();
 
-    selectedItemNotifier =
-        widget.controller ?? SingleSelectController(widget.initialItem);
+    selectedItemNotifier = widget.controller ?? SingleSelectController(widget.initialItem);
 
-    selectedItemsNotifier = widget.multiSelectController ??
-        MultiSelectController(widget.initialItems ?? []);
+    selectedItemsNotifier =
+        widget.multiSelectController ?? MultiSelectController(widget.initialItems ?? []);
 
-    selectedItemNotifier.addListener(_selectedItemListener);
+    selectedItemNotifier.addListener(() {
+      widget.onChanged?.call(selectedItemNotifier.value);
+      _formFieldState?.didChange((selectedItemNotifier.value, []));
+      if (widget.validateOnChange) {
+        _formFieldState?.validate();
+      }
+    });
 
-    selectedItemsNotifier.addListener(_selectedItemsListener);
+    selectedItemsNotifier.addListener(() {
+      widget.onListChanged?.call(selectedItemsNotifier.value);
+      _formFieldState?.didChange((null, selectedItemsNotifier.value));
+      if (widget.validateOnChange) {
+        _formFieldState?.validate();
+      }
+    });
   }
 
   @override
@@ -559,8 +550,7 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
       });
     }
 
-    if (widget.controller != oldWidget.controller &&
-        widget.controller != null) {
+    if (widget.controller != oldWidget.controller && widget.controller != null) {
       selectedItemNotifier = widget.controller!;
     }
 
@@ -574,16 +564,11 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
   void dispose() {
     if (widget.controller == null) {
       selectedItemNotifier.dispose();
-    } else {
-      selectedItemNotifier.removeListener(_selectedItemListener);
     }
 
     if (widget.multiSelectController == null) {
       selectedItemsNotifier.dispose();
-    } else {
-      selectedItemsNotifier.removeListener(_selectedItemsListener);
     }
-
     super.dispose();
   }
 
@@ -599,8 +584,7 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
       child: FormField<(T?, List<T>)>(
         initialValue: (selectedItemNotifier.value, selectedItemsNotifier.value),
         validator: (val) {
-          if (widget._dropdownType == _DropdownType.singleSelect &&
-              widget.validator != null) {
+          if (widget._dropdownType == _DropdownType.singleSelect && widget.validator != null) {
             return widget.validator!(val?.$1);
           }
           if (widget._dropdownType == _DropdownType.multipleSelect &&
@@ -617,6 +601,8 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
               errorText: formFieldState.errorText,
               border: InputBorder.none,
               contentPadding: EdgeInsets.zero,
+              fillColor: formFieldState.hasError ? Colors.transparent : decoration?.closedFillColor,
+              filled: true,
             ),
             child: _OverlayBuilder(
               overlayPortalController: widget.overlayController,
@@ -637,8 +623,7 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
                         selectedItemsNotifier.value = currentVal;
                     }
                   },
-                  noResultFoundText:
-                      widget.noResultFoundText ?? 'No result found.',
+                  noResultFoundText: widget.noResultFoundText ?? 'No result found.',
                   noResultFoundBuilder: widget.noResultFoundBuilder,
                   items: widget.items ?? [],
                   itemsScrollCtrl: widget.itemsScrollController,
@@ -664,14 +649,12 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
                   searchType: widget._searchType,
                   futureRequest: widget.futureRequest,
                   futureRequestDelay: widget.futureRequestDelay,
-                  hideSelectedFieldWhenOpen:
-                      widget.hideSelectedFieldWhenExpanded,
+                  hideSelectedFieldWhenOpen: widget.hideSelectedFieldWhenExpanded,
                   maxLines: widget.maxlines,
                   headerPadding: widget.expandedHeaderPadding,
                   itemsListPadding: widget.itemsListPadding,
                   listItemPadding: widget.listItemPadding,
-                  searchRequestLoadingIndicator:
-                      widget.searchRequestLoadingIndicator,
+                  searchRequestLoadingIndicator: widget.searchRequestLoadingIndicator,
                   dropdownType: widget._dropdownType,
                 );
               },
@@ -691,28 +674,19 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
                         : enabled
                             ? decoration?.closedBorderRadius
                             : disabledDecoration?.borderRadius,
-                    shadow: enabled
-                        ? decoration?.closedShadow
-                        : disabledDecoration?.shadow,
-                    hintStyle: enabled
-                        ? decoration?.hintStyle
-                        : disabledDecoration?.hintStyle,
-                    headerStyle: enabled
-                        ? decoration?.headerStyle
-                        : disabledDecoration?.headerStyle,
+                    shadow: enabled ? decoration?.closedShadow : disabledDecoration?.shadow,
+                    hintStyle: enabled ? decoration?.hintStyle : disabledDecoration?.hintStyle,
+                    headerStyle:
+                        enabled ? decoration?.headerStyle : disabledDecoration?.headerStyle,
                     hintText: safeHintText,
                     hintBuilder: widget.hintBuilder,
                     headerBuilder: widget.headerBuilder,
                     headerListBuilder: widget.headerListBuilder,
-                    prefixIcon: enabled
-                        ? decoration?.prefixIcon
-                        : disabledDecoration?.prefixIcon,
-                    suffixIcon: enabled
-                        ? decoration?.closedSuffixIcon
-                        : disabledDecoration?.suffixIcon,
-                    fillColor: enabled
-                        ? decoration?.closedFillColor
-                        : disabledDecoration?.fillColor,
+                    prefixIcon: enabled ? decoration?.prefixIcon : disabledDecoration?.prefixIcon,
+                    suffixIcon:
+                        enabled ? decoration?.closedSuffixIcon : disabledDecoration?.suffixIcon,
+                    fillColor:
+                        enabled ? decoration?.closedFillColor : disabledDecoration?.fillColor,
                     maxLines: widget.maxlines,
                     headerPadding: widget.closedHeaderPadding,
                     dropdownType: widget._dropdownType,

--- a/lib/custom_dropdown.dart
+++ b/lib/custom_dropdown.dart
@@ -613,6 +613,7 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
                     switch (widget._dropdownType) {
                       case _DropdownType.singleSelect:
                         selectedItemNotifier.value = value;
+                        break;
                       case _DropdownType.multipleSelect:
                         final currentVal = selectedItemsNotifier.value.toList();
                         if (currentVal.contains(value)) {
@@ -621,6 +622,7 @@ class _CustomDropdownState<T> extends State<CustomDropdown<T>> {
                           currentVal.add(value);
                         }
                         selectedItemsNotifier.value = currentVal;
+                        break;
                     }
                   },
                   noResultFoundText: widget.noResultFoundText ?? 'No result found.',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -71,18 +71,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -111,18 +111,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -180,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -196,10 +196,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
 sdks:
   dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animated_custom_dropdown
 description: Custom dropdown widget allows to add highly customizable dropdown widget in your projects. Features includes Search on list data, Network search, Multi-selection and many more.
-version: 3.1.1
+version: 3.1.2
 homepage: https://github.com/AbdullahChauhan/custom-dropdown
 
 environment:


### PR DESCRIPTION
## Bug Fixes

### CustomDropdown Error Background

- Resolved an issue where a gray background would appear when an error message was displayed in the `CustomDropdown` widget.
- The `InputDecorator` now sets the `fillColor` to `Colors.transparent` when an error occurs, ensuring a consistent and clean appearance.
- This change helps maintain the visual integrity of the dropdown, especially in forms where error messages are displayed.

<img width="338" alt="image" src="https://github.com/user-attachments/assets/c8b6f72d-bf7c-4045-a970-7db5f3c5a20a">
