### PR TITLE
[FEAT] Allow the user control the onItemSelect behaviour

### DIFF
--- a/lib/custom_dropdown.dart
+++ b/lib/custom_dropdown.dart
@@ -46,7 +46,9 @@ const _defaultErrorStyle = TextStyle(
 );
 
 class CustomDropdown<T> extends StatefulWidget {
-  /// The list of items user can select.
+  /// The list of items user can select. This can be where a [String]
+  /// or any custom object using the [listItemBuilder]. to correctly
+  /// display the item as per the user's requirement.E
   final List<T>? items;
 
   /// Initial selected item from the list of [items].

--- a/lib/widgets/dropdown_overlay/dropdown_overlay.dart
+++ b/lib/widgets/dropdown_overlay/dropdown_overlay.dart
@@ -270,7 +270,8 @@ class _DropdownOverlayState<T> extends State<_DropdownOverlay<T>> {
     final list = items.isNotEmpty
         ? _ItemsList<T>(
             scrollController: scrollController,
-            listItemBuilder: widget.listItemBuilder ?? defaultListItemBuilder,
+            listItemBuilder: widget.listItemBuilder,
+            defaultItemBuilder: defaultListItemBuilder,
             excludeSelected: items.length > 1 ? widget.excludeSelected : false,
             selectedItem: selectedItem,
             selectedItems: selectedItems,

--- a/lib/widgets/dropdown_overlay/widgets/items_list.dart
+++ b/lib/widgets/dropdown_overlay/widgets/items_list.dart
@@ -7,9 +7,10 @@ class _ItemsList<T> extends StatelessWidget {
   final Function(T) onItemSelect;
   final bool excludeSelected;
   final EdgeInsets itemsListPadding, listItemPadding;
-  final _ListItemBuilder<T> listItemBuilder;
+  final _ListItemBuilder<T>? listItemBuilder;
   final ListItemDecoration? decoration;
   final _DropdownType dropdownType;
+  final _ListItemBuilder<T> defaultItemBuilder;
 
   const _ItemsList({
     super.key,
@@ -24,6 +25,7 @@ class _ItemsList<T> extends StatelessWidget {
     required this.selectedItems,
     required this.decoration,
     required this.dropdownType,
+    required this.defaultItemBuilder,
   });
 
   @override
@@ -41,6 +43,19 @@ class _ItemsList<T> extends StatelessWidget {
               !excludeSelected && selectedItem == items[index],
             _DropdownType.multipleSelect => selectedItems.contains(items[index])
           };
+
+          if (listItemBuilder != null) {
+            return Padding(
+              padding: listItemPadding,
+              child: listItemBuilder!(
+                context,
+                items[index],
+                selected,
+                () => onItemSelect(items[index]),
+              ),
+            );
+          }
+
           return Material(
             color: Colors.transparent,
             child: InkWell(
@@ -55,7 +70,7 @@ class _ItemsList<T> extends StatelessWidget {
                         ListItemDecoration._defaultSelectedColor)
                     : Colors.transparent,
                 padding: listItemPadding,
-                child: listItemBuilder(
+                child: defaultItemBuilder(
                   context,
                   items[index],
                   selected,


### PR DESCRIPTION
This pull request includes changes to the custom dropdown component to improve flexibility and customization. The most important changes include updating the `CustomDropdown` and `_ItemsList` classes to support both custom and default item builders.

Closes #80 

Enhancements to `CustomDropdown` and `_ItemsList`:

* [`lib/custom_dropdown.dart`](diffhunk://#diff-be11cfae14f199da84839dde0a74643cc14bfc411cc0aa64e658f6649b650390L49-R51): Updated the documentation for the `items` parameter in the `CustomDropdown` class to clarify that it can be a `String` or any custom object using the `listItemBuilder`.
* [`lib/widgets/dropdown_overlay/dropdown_overlay.dart`](diffhunk://#diff-8e21ca10774bcbb7dddf4b622f5a8ad9b379bd51ba0c949c9ded07aba8395b81L273-R274): Modified the `_DropdownOverlayState` class to include both `listItemBuilder` and `defaultItemBuilder` parameters for item rendering.
* [`lib/widgets/dropdown_overlay/widgets/items_list.dart`](diffhunk://#diff-32d88d4d876d97f505830afab73d4071989c15bd50f2d2c1968bd716341c203fL10-R13): Updated the `_ItemsList` class to optionally use a custom `listItemBuilder` if provided, otherwise falling back to the `defaultItemBuilder`. This includes changes to the constructor and the item rendering logic. 
